### PR TITLE
Implement delete endpoint for batch response deletion

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
     <option name="myRunOnSave" value="true" />
   </component>
 </project>

--- a/app/Validators/Response/DeleteMultipleResponseValidator.ts
+++ b/app/Validators/Response/DeleteMultipleResponseValidator.ts
@@ -1,0 +1,20 @@
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { rules, schema } from '@ioc:Adonis/Core/Validator'
+
+export default class DeleteMultipleResponseValidator {
+  constructor(private ctx: HttpContextContract) {}
+
+  public schema = schema.create({
+    ids: schema.array([rules.minLength(1)]).members(
+      schema.number([
+        rules.exists({
+          column: 'id',
+          table: 'responses',
+          where: { route_id: this.ctx.params.id },
+        }),
+      ])
+    ),
+  })
+
+  public messages = this.ctx.i18n.validatorMessages('validator.response.deleteMany')
+}

--- a/resources/lang/en/validator.json
+++ b/resources/lang/en/validator.json
@@ -77,6 +77,11 @@
       "name.required": "A name is necessary for your response",
       "name.maxLength": "The name can't be more than 200 characters long",
       "name.unique": "This response name already exists"
+    },
+    "deleteMany": {
+      "ids.required": "You need to indicate which responses you want to delete",
+      "ids.minLength": "You need to indicate at least one response",
+      "ids.exists": "There is a response that does not exist"
     }
   },
   "processor": {

--- a/resources/lang/es/validator.json
+++ b/resources/lang/es/validator.json
@@ -77,6 +77,11 @@
       "name.required": "Es necesario un nombre para tu respuesta",
       "name.maxLength": "El nombre no puede tener más de 200 carácteres",
       "name.unique": "Este nombre de respuesta ya existe"
+    },
+    "deleteMany": {
+      "ids.required": "Es necesario que indiques el listado de respuestas a eliminar",
+      "ids.minLength": "Tienes que indicar al menos una respuesta",
+      "ids.exists": "Hay una respuesta que no existe"
     }
   },
   "processor": {

--- a/start/routes/responses.ts
+++ b/start/routes/responses.ts
@@ -1,7 +1,6 @@
 import Route from '@ioc:Adonis/Core/Route'
 
 Route.group(() => {
-  Route.delete('selected', 'ResponsesController.deleteMultiple')
   Route.get(':id', 'ResponsesController.get')
   Route.put(':id', 'ResponsesController.edit')
   Route.delete(':id', 'ResponsesController.delete')

--- a/start/routes/responses.ts
+++ b/start/routes/responses.ts
@@ -1,6 +1,7 @@
 import Route from '@ioc:Adonis/Core/Route'
 
 Route.group(() => {
+  Route.delete('selected', 'ResponsesController.deleteMultiple')
   Route.get(':id', 'ResponsesController.get')
   Route.put(':id', 'ResponsesController.edit')
   Route.delete(':id', 'ResponsesController.delete')

--- a/start/routes/routes.ts
+++ b/start/routes/routes.ts
@@ -6,4 +6,5 @@ Route.group(() => {
   Route.delete(':id', 'RoutesController.delete')
   Route.post(':id/responses', 'ResponsesController.create')
   Route.get(':id/responses', 'ResponsesController.getList')
+  Route.delete(':id/responses', 'ResponsesController.deleteMultiple')
 }).prefix('routes')


### PR DESCRIPTION
This pull request adds a delete endpoint that allows deleting multiple responses by receiving their IDs in the request payload. This improves efficiency by enabling batch deletion in a single request.